### PR TITLE
Added support for JSON5 special real values

### DIFF
--- a/json_spirit/json_spirit_reader_template.h
+++ b/json_spirit/json_spirit_reader_template.h
@@ -290,6 +290,11 @@ namespace json_spirit
             add_to_current( d );
         }
 
+      void new_special_real( Iter_type begin, Iter_type end )
+      {
+        add_to_current(std::stod(std::string(begin,end)));
+      }
+      
     private:
 
         Semantic_actions& operator=( const Semantic_actions& ); 
@@ -430,6 +435,7 @@ namespace json_spirit
                 typedef boost::function< void( Char_type )            > Char_action;
                 typedef boost::function< void( Iter_type, Iter_type ) > Str_action;
                 typedef boost::function< void( double )               > Real_action;
+                typedef boost::function< void( )               > Special_real_action;
                 typedef boost::function< void( boost::int64_t )       > Int_action;
                 typedef boost::function< void( boost::uint64_t )      > Uint64_action;
 
@@ -443,6 +449,7 @@ namespace json_spirit
                 Str_action    new_false  ( boost::bind( &Semantic_actions_t::new_false,   &self.actions_, _1, _2 ) );
                 Str_action    new_null   ( boost::bind( &Semantic_actions_t::new_null,    &self.actions_, _1, _2 ) );
                 Real_action   new_real   ( boost::bind( &Semantic_actions_t::new_real,    &self.actions_, _1 ) );
+                Str_action    new_special_real ( boost::bind( &Semantic_actions_t::new_special_real,    &self.actions_, _1, _2) );
                 Int_action    new_int    ( boost::bind( &Semantic_actions_t::new_int,     &self.actions_, _1 ) );
                 Uint64_action new_uint64 ( boost::bind( &Semantic_actions_t::new_uint64,  &self.actions_, _1 ) );
 
@@ -504,6 +511,9 @@ namespace json_spirit
                     = strict_real_p[ new_real   ] 
                     | int64_p      [ new_int    ]
                     | uint64_p     [ new_uint64 ]
+                    | str_p("Infinity")[ new_special_real ]
+                    | str_p("-Infinity")[ new_special_real ]
+                    | str_p("NaN")[ new_special_real ]
                     ;
             }
 

--- a/json_spirit/json_spirit_reader_template.h
+++ b/json_spirit/json_spirit_reader_template.h
@@ -292,7 +292,7 @@ namespace json_spirit
 
       void new_special_real( Iter_type begin, Iter_type end )
       {
-        add_to_current(std::stod(std::string(begin,end)));
+        add_to_current(strtod(std::string(begin,end).c_str(),NULL));
       }
       
     private:

--- a/json_spirit/json_spirit_reader_template.h
+++ b/json_spirit/json_spirit_reader_template.h
@@ -16,7 +16,7 @@
 
 //#define BOOST_SPIRIT_THREADSAFE  // uncomment for multithreaded use, requires linking to boost.thread
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/version.hpp>
 
@@ -38,6 +38,7 @@
 
 namespace json_spirit
 {
+    using namespace boost::placeholders;
     const spirit_namespace::int_parser < boost::int64_t >  int64_p  = spirit_namespace::int_parser < boost::int64_t  >();
     const spirit_namespace::uint_parser< boost::uint64_t > uint64_p = spirit_namespace::uint_parser< boost::uint64_t >();
 

--- a/json_spirit/json_spirit_writer_template.h
+++ b/json_spirit/json_spirit_writer_template.h
@@ -15,6 +15,7 @@
 #include "json_spirit_writer_options.h"
 
 #include <iomanip>
+#include <cmath>
 #include <boost/io/ios_state.hpp>
 
 namespace json_spirit
@@ -242,6 +243,7 @@ namespace json_spirit
 
         void output( double d )
         {
+          if (std::isfinite(d))
             if( remove_trailing_zeros_ )
             {
                 std::basic_ostringstream< Char_type > os;
@@ -259,6 +261,12 @@ namespace json_spirit
             {
                 append_double( os_, d, 17 );
             }
+          // use Javascript names for non-finite values (ie JSON5).
+          else if (std::isnan(d))
+            os_<<"NaN";
+          else // is infinite
+            os_<<(d<0?"-":"")<<"Infinity";
+            
         }
 
         static bool contains_composite_elements( const Array_type& arr )

--- a/json_test/json_spirit_reader_test.cpp
+++ b/json_test/json_spirit_reader_test.cpp
@@ -158,6 +158,9 @@ namespace
             test_syntax( INT_MIN, INT_MAX );
             test_syntax( LLONG_MIN, LLONG_MAX );
             test_syntax( "[1 2 3]", false );
+            test_syntax( "NaN" );
+            test_syntax( "Infinity" );
+            test_syntax( "-Infinity" );
         }
 
         Value_type read_cstr( const char* c_str )

--- a/json_test/json_spirit_writer_test.cpp
+++ b/json_test/json_spirit_writer_test.cpp
@@ -577,6 +577,9 @@ namespace
         {
             check_eq( 123, "123" );
             check_eq( 1.234, "1.2340000000000000" );
+            check_eq( nan(""), "NaN");
+            check_eq( std::stod("inf"), "Infinity");
+            check_eq( -std::stod("inf"), "-Infinity");
             check_eq( to_str( "abc" ), "\"abc\"" );
             check_eq( false, "false" );
             check_eq( Value_type::null, "null" );

--- a/json_test/json_spirit_writer_test.cpp
+++ b/json_test/json_spirit_writer_test.cpp
@@ -10,6 +10,7 @@
 #include "json_spirit_value.h" 
 
 #include <sstream>
+#include <string>
 #include <boost/integer_traits.hpp>
 
 using namespace json_spirit;
@@ -578,8 +579,8 @@ namespace
             check_eq( 123, "123" );
             check_eq( 1.234, "1.2340000000000000" );
             check_eq( nan(""), "NaN");
-            check_eq( std::stod("inf"), "Infinity");
-            check_eq( -std::stod("inf"), "-Infinity");
+            check_eq( INFINITY, "Infinity");
+            check_eq( -INFINITY, "-Infinity");
             check_eq( to_str( "abc" ), "\"abc\"" );
             check_eq( false, "false" );
             check_eq( Value_type::null, "null" );


### PR DESCRIPTION
This enables support for real special values, such as inf and nan. The json values they're mapped to are documented in the JSON5 proposal, namely the corresponding ECMAscript values.